### PR TITLE
fix: Forçar recriação de tabela para resolver problema de esquema

### DIFF
--- a/migrate_for_railway.py
+++ b/migrate_for_railway.py
@@ -34,11 +34,15 @@ def migrate_from_csv():
         Session = sessionmaker(bind=engine)
         session = Session()
         
+        # Forçar a recriação da tabela para garantir o esquema mais recente
+        print("💣 Excluindo tabela structured_entries para garantir atualização do esquema...")
+        StructuredEntry.__table__.drop(engine, checkfirst=True)
+
         # Criar tabelas
-        print("📋 Criando tabelas no PostgreSQL...")
+        print("📋 Criando tabelas no PostgreSQL (com esquema atualizado)...")
         Base.metadata.create_all(engine)
         
-        # Limpar tabelas existentes
+        # Limpar tabelas existentes (redundante se a tabela foi dropada, mas seguro)
         print("🧹 Limpando dados existentes...")
         session.execute(text("DELETE FROM structured_entries"))
         session.execute(text("DELETE FROM raw_entries"))


### PR DESCRIPTION
O script de migração do Railway não estava atualizando o esquema de tabelas existentes, causando um erro de 'coluna inexistente' quando o modelo de dados era atualizado.

Esta correção modifica o script `migrate_for_railway.py` para explicitamente excluir (DROP) a tabela `structured_entries` antes de recriá-la. Isso garante que o esquema do banco de dados no ambiente de deploy sempre corresponda ao esquema definido no código da aplicação, resolvendo o erro.

Nota: Esta abordagem é destrutiva e irá apagar e recarregar os dados da tabela a cada deploy.