### PR TITLE
fix: Executar migração antes de iniciar a aplicação no Railway

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python web_app.py",
+    "startCommand": "python migrate_for_railway.py && python web_app.py",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
O comando de inicialização no `railway.json` estava apenas iniciando a aplicação web (`web_app.py`) e não executava o script de migração do banco de dados.

Esta alteração atualiza o `startCommand` para encadear a execução do script de migração (`migrate_for_railway.py`) antes de iniciar a aplicação. O uso de `&&` garante que a aplicação só inicie se a migração for concluída com sucesso.

Isso resolve o erro de 'coluna inexistente' ao garantir que o esquema do banco de dados esteja sempre atualizado antes que a aplicação comece a atendê-lo.