### PR TITLE
fix: Definir corretamente a chave estrangeira em StructuredEntry

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,7 +1,7 @@
 """
 Módulo de banco de dados para AgenticLead
 """
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean, Float, Text, JSON
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean, Float, Text, JSON, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from datetime import datetime
@@ -27,7 +27,7 @@ class StructuredEntry(Base):
     __tablename__ = 'structured_entries'
     
     id = Column(Integer, primary_key=True, autoincrement=True)
-    raw_text_id = Column(Integer, nullable=False)  # FK para raw_entries
+    raw_text_id = Column(Integer, ForeignKey('raw_entries.id'), nullable=False)
     
     # Campos extraídos
     data_contato = Column(String(10))  # YYYY-MM-DD


### PR DESCRIPTION
O modelo StructuredEntry tinha uma coluna `raw_text_id` que pretendia ser uma chave estrangeira, mas não estava definida como tal no SQLAlchemy, faltando o objeto `ForeignKey`.

Isso causava um erro `psycopg2.errors.InvalidForeignKey` durante a criação da tabela no PostgreSQL, pois não havia uma restrição de chave estrangeira válida.

Esta correção adiciona a definição explícita `ForeignKey('raw_entries.id')` à coluna `raw_text_id` e importa o `ForeignKey` de `sqlalchemy`. Isso estabelece a relação correta no nível do banco de dados e resolve o erro de deploy.